### PR TITLE
Changed new.lwjgl.org to www.lwjgl.org

### DIFF
--- a/www/index.php
+++ b/www/index.php
@@ -220,7 +220,7 @@ if (!$detect->isMobile() && !$detect->isTablet()) {
 			</div><div class=col-md-4>
 				<p><i class="fa fa-github"></i></p>
 				<h3>Open Source</h3>
-				<p>LWJGL is available under a <a href="http://new.lwjgl.org/license">BSD license</a>. Visit our
+				<p>LWJGL is available under a <a href="http://www.lwjgl.org/license">BSD license</a>. Visit our
 				<a href="https://github.com/LWJGL/lwjgl3">GitHub repository</a> to monitor progress, report issues
 				and even contribute with your own code!</p>
 			</div><div class=col-md-4>


### PR DESCRIPTION
The domain new.lwjgl.org for the license link does not appear to work. This may just be me, but I would not think so. I asked in the IRC and got no response a while back, so I just decided to send this. Being that this is a new website and that may have been done in a transitioning period, I am assuming the subdomain was removed but this file was not changed. Plus, http://www.lwjgl.org/licence does in fact contain a BSD-style license, as was described, so I believe this is okay.

Changed http://new.lwjgl.org/license to http://www.lwjgl.org/license on line 223.