### PR TITLE
Changed the getting started guide for the new init code of 3.0.0b

### DIFF
--- a/www/guide.php
+++ b/www/guide.php
@@ -44,7 +44,9 @@ include "header.php"
 	</ul>
 	</p>
 	
-	<p>If you'd like to use Maven or Gradle, see <a href="https://github.com/badlogic/lwjgl3-maven-gradle">this example project</a>.</p>
+        <p>If you'd like to use Maven or Gradle, see <a href="https://github.com/badlogic/lwjgl3-maven-gradle">this example project</a>.
+            You may also use Ant with Ivy, like described in <a href="https://github.com/SilverTiger/lwjgl3-tutorial/wiki/Setup">this wiki page</a>.
+        </p>
 	
 	<p>You should now be ready to develop and launch an LWJGL application. Following is a simple example that utilizes GLFW to create a window and clear the background color to red, using OpenGL:</p>
 </section>

--- a/www/guide.php
+++ b/www/guide.php
@@ -142,7 +142,7 @@ public class HelloWorld {
 		// LWJGL detects the context that is current in the current thread,
 		// creates the ContextCapabilities instance and makes the OpenGL
 		// bindings available for use.
-		GLContext.createFromCurrent();
+		GL.createCapabilities();
 
 		// Set the clear color
 		glClearColor(1.0f, 0.0f, 0.0f, 0.0f);


### PR DESCRIPTION
It may confuses people if the example code won't work with the current nightly version. Maybe the guide should provide a comment for GLContext.createFromCurrent() and GL.createCapabilities() until the new init code is a stable release?

The second commit is optional for adding an Ant Ivy example since it is one of the three main build tools for java applications.