### PR TITLE
Support for Gradle scripts in Kotlin

### DIFF
--- a/client/routes/customize/BuildConfigurator/constants.js
+++ b/client/routes/customize/BuildConfigurator/constants.js
@@ -12,3 +12,6 @@ export const MODE_ZIP = 'zip';
 export const MODE_MAVEN = 'maven';
 export const MODE_GRADLE = 'gradle';
 export const MODE_IVY = 'ivy';
+
+export const LANGUAGE_GROOVY = 'groovy';
+export const LANGUAGE_KOTLIN = 'kotlin';

--- a/client/routes/customize/BuildConfigurator/fields.js
+++ b/client/routes/customize/BuildConfigurator/fields.js
@@ -63,8 +63,7 @@ export const fields = {
     options: ({ build: { languages } }: State) =>
       languages.allIds.map((lang: LANGUAGES) => ({
         value: lang,
-        label: languages.byId[lang].title,
-        disabled: lang !== 'groovy',
+        label: languages.byId[lang].title
       })),
   },
   version: {

--- a/client/routes/customize/BuildConfigurator/reducer.js
+++ b/client/routes/customize/BuildConfigurator/reducer.js
@@ -2,7 +2,7 @@
 import produce from 'immer';
 import { register } from '~/store/asyncReducers';
 import { config } from './config';
-import { BUILD_RELEASE, BUILD_STABLE, MODE_ZIP, MODE_MAVEN, MODE_IVY } from './constants';
+import { BUILD_RELEASE, BUILD_STABLE, MODE_ZIP, MODE_MAVEN, MODE_GRADLE, MODE_IVY } from './constants';
 import type {
   BUILD_TYPES,
   NATIVES,
@@ -180,8 +180,11 @@ function buildConfiguratorReducer(state: BuildConfig = config, action: Action) {
         }
         break;
 
-      // case SELECT_LANGUAGE:
-      //   break;
+      case SELECT_LANGUAGE:
+        if (state.mode === MODE_GRADLE) {
+          draft.language = action.language;
+        }
+        break;
 
       case TOGGLE_PLATFORM:
         const selections = state.natives.allIds.reduce(


### PR DESCRIPTION
Rudimentary attempt to support Gradle scripts written in Kotlin.

#### Notes

- The Kotlin version works almost exactly like the Groovy version. (The only difference is that the Kotlin script throws if the operating system cannot be detected while the Groovy version fails to resolve all dependencies.)

- `"compile"(...)` is used instead of `compile(...)` since the latter is only available if a plugin that is visible during script compilation creates a `compile` configuration.

- All addon names are wrapped in ``` ` ``` to avoid issues with names that contain characters that are invalid for identifiers. (e.g. `-` in `steamworks4j-server`)