### PR TITLE
Removed The Broken LWJGL2 Wiki Link From Downloads, Since It Seems Like It Has Been Down For A Few Years

### DIFF
--- a/client/routes/download/index.tsx
+++ b/client/routes/download/index.tsx
@@ -107,9 +107,6 @@ const DownloadRoute: React.FC = (): JSX.Element => {
           <AnchorButton variant="outline" href="http://legacy.lwjgl.org/" rel="noopener external">
             LWJGL 2 WEBSITE
           </AnchorButton>
-          <AnchorButton variant="outline" href="http://wiki.lwjgl.org/" rel="noopener external">
-            LWJGL 2 WIKI
-          </AnchorButton>
         </Grid>
       </Container>
     </PageView>


### PR DESCRIPTION
It seems like the LWGJL2 wiki has been down for a few years.  The last working archive was from 2021. It's probably best to remove it, since I highly doubt it will ever come back online.


(Example)

https://github.com/LWJGL/lwjgl3-www/assets/65189871/ee7f82a8-ca77-43bb-bab9-637614c3711e

Relevant Links:

https://www.lwjgl.org/download

https://wiki.lwjgl.org

