### PR TITLE
ui: have kotlin customizer use single-string notation

### DIFF
--- a/client/routes/customize/lib/gradle.ts
+++ b/client/routes/customize/lib/gradle.ts
@@ -203,8 +203,8 @@ dependencies {`;
       script += `\n\timplementation "${groupId}:${artifactId}:${hardcoded ? version : `\${${id}Version}`}"`;
     });
   } else {
-    const v = hasBoM ? '' : `, ${hardcoded ? `"${versionString}"` : 'lwjglVersion'}`;
-    const classifier = !hardcoded || platformSingle == null ? 'lwjglNatives' : `"natives-${platformSingle}"`;
+    const v = hasBoM ? '' : hardcoded ? versionString : '$lwjglVersion';
+    const classifier = !hardcoded || platformSingle == null ? '$lwjglNatives' : `natives-${platformSingle}`;
     if (hasBoM) {
       script += `
 \timplementation(platform("org.lwjgl:lwjgl-bom:${hardcoded ? versionString : '$lwjglVersion'}"))
@@ -216,20 +216,20 @@ dependencies {`;
       platform,
       osgi,
       (artifact, groupId, artifactId, hasEnabledNativePlatform) =>
-        `\n\timplementation("${groupId}", "${artifactId}"${v})`,
+        `\n\timplementation("${groupId}:${artifactId}${v?':':''}${v}")`,
       (artifact, groupId, artifactId) =>
         `\n\t${guardNative(
           artifact,
           platform,
-        )}implementation ("${groupId}", "${artifactId}"${v}, classifier = ${classifier})`,
+        )}implementation("${groupId}:${artifactId}:${v}:${classifier}")`,
     );
 
     selectedAddons.forEach((id: Addon) => {
       const {
         maven: { groupId, artifactId, version },
       } = addons[id];
-      const v = id.indexOf('-') === -1 ? `${id}Version` : `\`${id}Version\``;
-      script += `\n\timplementation("${groupId}", "${artifactId}", ${hardcoded ? `"${version}"` : v})`;
+      const v = id.indexOf('-') === -1 ? `$${id}Version` : `$\{\`${id}Version\`}`;
+      script += `\n\timplementation("${groupId}:${artifactId}:${hardcoded ? `${version}` : v}")`;
     });
   }
 


### PR DESCRIPTION
Multi-string notation has been deprecated.
<img width="834" height="412" alt="image" src="https://github.com/user-attachments/assets/26bee84e-ac4e-43a1-9b43-1f8161c2ea7f" />

Also I kind of wish that both
https://build.lwjgl.org/release/3.4.1/bin/build.txt
https://build.lwjgl.org/nightly/bin/build.txt
had cors header to make local development easier.

Also I kind of wish that the classifiers were changed to match the os-maven-plugin.
https://github.com/LWJGL/lwjgl3/issues/1055
so that https://github.com/google/osdetector-gradle-plugin could be used.